### PR TITLE
Fix missing templates in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
                             'tsproxy = touchandgo.server:serve']
     },
     package_data={
-        'touchandgo/templates': ['*'],
+        'touchandgo': ['templates/*'],
     },
 )


### PR DESCRIPTION
The templates folder was not being included in the distribution, so loading http://server:5000/ ended up in a Jinja2 exception:

![exception](http://i.imgur.com/z7qWi9n.png)
